### PR TITLE
fix(core): fixing cspell throwing error when 0 files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 const config = {
-  '*': ['cspell', 'prettier --list-different'],
+  '*': ['cspell --no-must-find-files', 'prettier --list-different'],
   '**/*.{ts,tsx,js,jsx,cjs,mjs}': ['eslint'],
   '**/*.{md,mdx}': ['markdownlint'],
 };


### PR DESCRIPTION
cspell throws an error if no files in the commit is processed by cspell. This commit fixes that.