### PR TITLE
fix: fixed reset changelog script

### DIFF
--- a/.changeset/shiny-clouds-occur.md
+++ b/.changeset/shiny-clouds-occur.md
@@ -1,0 +1,20 @@
+---
+'@orbitkit/docs': patch
+'@orbitkit/marketing': patch
+'@orbitkit/web': patch
+'@orbitkit/api': patch
+'@orbitkit/assets': patch
+'@orbitkit/auth': patch
+'@orbitkit/eslint': patch
+'@orbitkit/storybook': patch
+'@orbitkit/tailwind': patch
+'@orbitkit/tsconfig': patch
+'@orbitkit/vite': patch
+'@orbitkit/core': patch
+'@orbitkit/db': patch
+'@orbitkit/env': patch
+'@orbitkit/ui': patch
+'@orbitkit/utils': patch
+---
+
+Fix: fixed issue with reset:changelog script

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:spell": "cspell \"**\" --gitignore --dot --no-progress --cache --unique ",
     "prepare": "husky",
     "release": "turbo run build lint typecheck && changeset version && changeset publish",
-    "reset:changelog": "bun run rm -rf **/CHANGELOG.md",
+    "reset:changelog": "bun run rm -rf */**/CHANGELOG.md",
     "typecheck": "tsc",
     "update:workspace": "bun run ./scripts/update-workspace"
   },


### PR DESCRIPTION
It came to my attention when testing the repo for #91 that we are missing an initial `*/` in the `reset:changelog` script.