### PR TITLE
feat(db): add drizzle-zod validation schemas for mutation input validation

### DIFF
--- a/.changeset/cuddly-impalas-hang.md
+++ b/.changeset/cuddly-impalas-hang.md
@@ -1,0 +1,5 @@
+---
+"@orbitkit/db": patch
+---
+
+feat(db): add drizzle-zod validation schemas for mutation input validation

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,6 +15,10 @@
     "./schema": {
       "types": "./dist/schema/index.d.ts",
       "default": "./dist/schema/index.js"
+    },
+    "./validation": {
+      "types": "./dist/validation/index.d.ts",
+      "default": "./dist/validation/index.js"
     }
   },
   "scripts": {
@@ -36,6 +40,7 @@
     "@neondatabase/serverless": "^0.9.4",
     "@orbitkit/env": "workspace:^",
     "drizzle-orm": "^0.33.0",
+    "drizzle-zod": "^0.5.1",
     "pg": "^8.12.0",
     "postgres": "^3.4.4",
     "zod": "^3.23.8"

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,3 +1,4 @@
 export * from './user'
 export * from './session'
 export * from './oauth'
+export * from '../validation'

--- a/packages/db/src/validation/index.ts
+++ b/packages/db/src/validation/index.ts
@@ -1,0 +1,42 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod'
+import { z } from 'zod'
+
+import { oauthAccountTable } from '../schema/oauth'
+import { sessionTable } from '../schema/session'
+import { userTable } from '../schema/user'
+
+// ─── User Schemas ────────────────────────────────────────────
+
+export const insertUserSchema = createInsertSchema(userTable, {
+  email: z.string().email('Invalid email address'),
+  name: z.string().min(1, 'Name is required').optional(),
+  avatarUrl: z.string().url('Invalid URL').optional(),
+})
+
+export const selectUserSchema = createSelectSchema(userTable)
+
+export type InsertUser = z.infer<typeof insertUserSchema>
+export type SelectUser = z.infer<typeof selectUserSchema>
+
+// ─── Session Schemas ─────────────────────────────────────────
+
+export const insertSessionSchema = createInsertSchema(sessionTable, {
+  expiresAt: z.date(),
+})
+
+export const selectSessionSchema = createSelectSchema(sessionTable)
+
+export type InsertSession = z.infer<typeof insertSessionSchema>
+export type SelectSession = z.infer<typeof selectSessionSchema>
+
+// ─── OAuth Account Schemas ───────────────────────────────────
+
+export const insertOAuthAccountSchema = createInsertSchema(oauthAccountTable, {
+  providerId: z.string().min(1, 'Provider ID is required'),
+  providerUserId: z.string().min(1, 'Provider User ID is required'),
+})
+
+export const selectOAuthAccountSchema = createSelectSchema(oauthAccountTable)
+
+export type InsertOAuthAccount = z.infer<typeof insertOAuthAccountSchema>
+export type SelectOAuthAccount = z.infer<typeof selectOAuthAccountSchema>


### PR DESCRIPTION
## Summary
Adds drizzle-zod integration to @orbitkit/db for automatic Zod schema generation from Drizzle tables.

## Changes
- Added drizzle-zod dependency
- Created validation/index.ts with insert/select schemas for User, Session, OAuth
- Custom Zod refinements (email, URL, min length)
- Exported TypeScript types
- New ./validation export path

Closes #66